### PR TITLE
Adds programmatically expanding/disabling/pinning the headers via controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+* [feature] - added `toggleExpanded` in the Sticker Header component
+* [feature] - added `isExpanded`,`isPinned`,`isDisabled` in the Sticker Header component to set and get these properties
+
 ## 2.0.7
 * [chore] - regenerate example with Flutter 3.24 for Android Studio Ladybug compatible
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Sliver implementation of sticky collapsable panel, with a box header rebuild o
 - Support iOS style sticky header, just like iOS's system contact app (with `iOSStyleSticky = true` parameter).
 - Support add padding for sliver child (with `paddingBeforeCollapse` parameter).
 - Support add padding after the header even the panel collapsed (with `paddingAfterCollapse` parameter).
+- Support setting/getting the collapsable panel expansion, pinned, and disabled status using `isExpanded`, `isPinned`, and `isDisabled` properties of the controller.
 
 ---
 ## Getting started
@@ -30,7 +31,7 @@ A Sliver implementation of sticky collapsable panel, with a box header rebuild o
 
     ```yaml
     dependencies:
-      sliver_sticky_collapsable_panel: ^2.0.7
+      sliver_sticky_collapsable_panel: ^2.1.0
     ```
 
 - In your library add the following import:
@@ -88,6 +89,13 @@ A Sliver implementation of sticky collapsable panel, with a box header rebuild o
     ```
 ---
 ## More Advanced Feature:
+
+- You can use the controller to set/get the status of the panel through `isExpanded`,`isPinned`,`isDisabled`.
+    ```dart
+    final StickyCollapsablePanelController panelController = StickyCollapsablePanelController(key:'key_1');
+    ...
+    panelController.isExpanded = true; // or panelController.toggleExpanded();
+    ```
 
 - You can disable collapse for any sliver you wanted, just add `disableCollapsable = true`.
     ```dart

--- a/lib/utils/sliver_sticky_collapsable_panel_controller.dart
+++ b/lib/utils/sliver_sticky_collapsable_panel_controller.dart
@@ -2,18 +2,57 @@ import 'package:flutter/foundation.dart';
 
 /// Controller to manage Sticker Header
 class StickyCollapsablePanelController with ChangeNotifier {
-  StickyCollapsablePanelController({this.key = 'default'});
-
   final String key;
+
+  StickyCollapsablePanelController({this.key = 'default'});
 
   /// The offset used as calibration when collapse/expand the panel
   double _precedingScrollExtent = 0;
+
+  /// Whether the panel is expanded or collapsed
+  bool _isExpanded = false;
+
+  /// Whether the panel is disabled (non-interactive)
+  bool _isDisabled = false;
+
+  /// Whether the panel is pinned to its position
+  bool _isPinned = false;
 
   double get precedingScrollExtent => _precedingScrollExtent;
 
   set precedingScrollExtent(double value) {
     if (_precedingScrollExtent != value) {
       _precedingScrollExtent = value;
+      notifyListeners();
+    }
+  }
+
+  bool get isExpanded => _isExpanded;
+
+  set isExpanded(bool value) {
+    if (_isExpanded != value) {
+      _isExpanded = value;
+      notifyListeners();
+    }
+  }
+
+  void toggleExpanded() {
+    isExpanded = !isExpanded;
+  }
+
+  bool get isDisabled => _isDisabled;
+
+  set isDisabled(bool value) {
+        if (_isDisabled != value) {
+      _isDisabled = value;
+      notifyListeners();
+    }
+  }
+
+    bool get isPinned => _isPinned;
+  set isPinned(bool value) {
+    if (_isPinned != value) {
+      _isPinned = value;
       notifyListeners();
     }
   }

--- a/lib/utils/sliver_sticky_collapsable_panel_status.dart
+++ b/lib/utils/sliver_sticky_collapsable_panel_status.dart
@@ -19,7 +19,9 @@ class SliverStickyCollapsablePanelStatus {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! SliverStickyCollapsablePanelStatus) return false;
-    return scrollPercentage == other.scrollPercentage && isPinned == other.isPinned && isExpanded == other.isExpanded;
+    return scrollPercentage == other.scrollPercentage &&
+        isPinned == other.isPinned &&
+        isExpanded == other.isExpanded;
   }
 
   @override

--- a/lib/utils/value_layout_builder.dart
+++ b/lib/utils/value_layout_builder.dart
@@ -49,7 +49,8 @@ class BoxValueConstraints<T> extends BoxConstraints {
 /// See also:
 ///
 ///  * [LayoutBuilder].
-class ValueLayoutBuilder<T> extends ConstrainedLayoutBuilder<BoxValueConstraints<T>> {
+class ValueLayoutBuilder<T>
+    extends ConstrainedLayoutBuilder<BoxValueConstraints<T>> {
   /// Creates a widget that defers its building until layout.
   const ValueLayoutBuilder({
     super.key,
@@ -57,11 +58,14 @@ class ValueLayoutBuilder<T> extends ConstrainedLayoutBuilder<BoxValueConstraints
   });
 
   @override
-  RenderValueLayoutBuilder<T> createRenderObject(BuildContext context) => RenderValueLayoutBuilder<T>();
+  RenderValueLayoutBuilder<T> createRenderObject(BuildContext context) =>
+      RenderValueLayoutBuilder<T>();
 }
 
 class RenderValueLayoutBuilder<T> extends RenderBox
-    with RenderObjectWithChildMixin<RenderBox>, RenderConstrainedLayoutBuilder<BoxValueConstraints<T>, RenderBox> {
+    with
+        RenderObjectWithChildMixin<RenderBox>,
+        RenderConstrainedLayoutBuilder<BoxValueConstraints<T>, RenderBox> {
   @override
   double computeMinIntrinsicWidth(double height) {
     assert(_debugThrowIfNotCheckingIntrinsics());
@@ -89,7 +93,8 @@ class RenderValueLayoutBuilder<T> extends RenderBox
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     assert(debugCannotComputeDryLayout(
-      reason: 'Calculating the dry layout would require running the layout callback '
+      reason:
+          'Calculating the dry layout would require running the layout callback '
           'speculatively, which might mutate the live render object tree.',
     ));
     return Size.zero;
@@ -128,7 +133,8 @@ class RenderValueLayoutBuilder<T> extends RenderBox
   bool _debugThrowIfNotCheckingIntrinsics() {
     assert(() {
       if (!RenderObject.debugCheckingIntrinsics) {
-        throw FlutterError('ValueLayoutBuilder does not support returning intrinsic dimensions.\n'
+        throw FlutterError(
+            'ValueLayoutBuilder does not support returning intrinsic dimensions.\n'
             'Calculating the intrinsic dimensions would require running the layout '
             'callback speculatively, which might mutate the live render object tree.');
       }

--- a/lib/widgets/sliver_sticky_collapsable_panel.dart
+++ b/lib/widgets/sliver_sticky_collapsable_panel.dart
@@ -112,47 +112,45 @@ class SliverStickyCollapsablePanel extends StatefulWidget {
   State<StatefulWidget> createState() => SliverStickyCollapsablePanelState();
 }
 
-class SliverStickyCollapsablePanelState extends State<SliverStickyCollapsablePanel> {
-  late bool isExpanded;
+class SliverStickyCollapsablePanelState
+    extends State<SliverStickyCollapsablePanel> {
 
   @override
   void initState() {
     super.initState();
-    isExpanded = widget.defaultExpanded;
+    widget.panelController.isExpanded = widget.defaultExpanded;
+    widget.panelController.isDisabled = widget.disableCollapsable;
   }
 
   @override
   Widget build(BuildContext context) {
-    Widget boxHeader = ValueLayoutBuilder<SliverStickyCollapsablePanelStatus>(
-      builder: (context, constraints) => GestureDetector(
-        onTap: () {
-          if (!widget.disableCollapsable) {
-            setState(() {
-              isExpanded = !isExpanded;
-              if (constraints.value.isPinned) {
-                widget.scrollController.jumpTo(widget.panelController.precedingScrollExtent);
-              }
-            });
-            widget.expandCallback?.call(isExpanded);
-          }
-        },
-        child: widget.headerBuilder(context, constraints.value),
-      ),
-    );
-    final isExpandedNow = (widget.disableCollapsable || isExpanded);
-    return _SliverStickyCollapsablePanel(
-      boxHeader: boxHeader,
-      sliverPanel: SliverPadding(
-        padding: isExpandedNow ? widget.paddingBeforeCollapse : widget.paddingAfterCollapse,
-        sliver: isExpandedNow ? widget.sliverPanel : null,
-      ),
-      overlapsContent: widget.overlapsContent,
-      sticky: widget.sticky,
-      controller: widget.panelController,
-      isExpanded: isExpandedNow,
-      iOSStyleSticky: widget.iOSStyleSticky,
-      headerSize: widget.headerSize,
-    );
+    return ListenableBuilder(
+        listenable: widget.panelController,
+        builder: (context, _) {
+          Widget boxHeader =
+              ValueLayoutBuilder<SliverStickyCollapsablePanelStatus>(
+                          builder: (context, constraints) =>
+                widget.headerBuilder(context, constraints.value),
+                        );
+
+          final isExpandedNow = (widget.panelController.isDisabled ||
+              widget.panelController.isExpanded);
+          return _SliverStickyCollapsablePanel(
+            boxHeader: boxHeader,
+            sliverPanel: SliverPadding(
+              padding: isExpandedNow
+                  ? widget.paddingBeforeCollapse
+                  : widget.paddingAfterCollapse,
+              sliver: isExpandedNow ? widget.sliverPanel : null,
+            ),
+            overlapsContent: widget.overlapsContent,
+            sticky: widget.sticky,
+            controller: widget.panelController,
+            isExpanded: isExpandedNow,
+            iOSStyleSticky: widget.iOSStyleSticky,
+            headerSize: widget.headerSize,
+          );
+        });
   }
 }
 
@@ -160,7 +158,8 @@ class SliverStickyCollapsablePanelState extends State<SliverStickyCollapsablePan
 /// The header scrolls off the viewport only when the sliver does.
 ///
 /// Place this widget inside a [CustomScrollView] or similar.
-class _SliverStickyCollapsablePanel extends SlottedMultiChildRenderObjectWidget<Slot, RenderObject> {
+class _SliverStickyCollapsablePanel
+    extends SlottedMultiChildRenderObjectWidget<Slot, RenderObject> {
   /// Creates a sliver that displays the [boxHeader] before its [sliverPanel], unless
   /// [overlapsContent] it's true.
   /// The [boxHeader] stays pinned when it hits the start of the viewport until
@@ -236,7 +235,8 @@ class _SliverStickyCollapsablePanel extends SlottedMultiChildRenderObjectWidget<
   }
 
   @override
-  void updateRenderObject(BuildContext context, RenderSliverStickyCollapsablePanel renderObject) {
+  void updateRenderObject(
+      BuildContext context, RenderSliverStickyCollapsablePanel renderObject) {
     renderObject
       ..overlapsContent = overlapsContent
       ..sticky = sticky


### PR DESCRIPTION
Addresses issue #4 

Adds in ability to use: `isExpanded`, `isPinned`, `isDisabled`, and `toggleExpanded()` from the sticky header controller

`isExpanded`, `isPinned`, `isDisabled` act as both getter/setter.

  ```dart
  final StickyCollapsablePanelController panelController = StickyCollapsablePanelController(key:'key_1');
  ...
  panelController.isExpanded = true; // or panelController.toggleExpanded();
  ```